### PR TITLE
Remove null from fl upgrades

### DIFF
--- a/lib/models/fl_upgrades.dart
+++ b/lib/models/fl_upgrades.dart
@@ -4,13 +4,10 @@
 
 // TODO: Complete upgrades model, remove null data types
 class FLUpgrades {
-  Null activePrepaidMilestone;
-  Null successBundle;
   bool nonCompete;
   bool projectManagement;
-  Null extend;
   bool nDA;
-  Null assisted;
+  bool assisted;
   bool urgent;
   bool featured;
   bool nonpublic;
@@ -19,34 +16,25 @@ class FLUpgrades {
   bool sealed;
   bool pfOnly;
   bool ipContract;
-  Null recruiter;
-  Null listed;
 
-  FLUpgrades(
-      {this.activePrepaidMilestone,
-      this.successBundle,
-      this.nonCompete,
-      this.projectManagement,
-      this.extend,
-      this.nDA,
-      this.assisted,
-      this.urgent,
-      this.featured,
-      this.nonpublic,
-      this.fulltime,
-      this.qualified,
-      this.sealed,
-      this.pfOnly,
-      this.ipContract,
-      this.recruiter,
-      this.listed});
+  FLUpgrades({
+    this.nonCompete,
+    this.projectManagement,
+    this.nDA,
+    this.assisted,
+    this.urgent,
+    this.featured,
+    this.nonpublic,
+    this.fulltime,
+    this.qualified,
+    this.sealed,
+    this.pfOnly,
+    this.ipContract,
+  });
 
   FLUpgrades.fromJson(Map<String, dynamic> json) {
-    activePrepaidMilestone = json['active_prepaid_milestone'];
-    successBundle = json['success_bundle'];
     nonCompete = json['non_compete'];
     projectManagement = json['project_management'];
-    extend = json['extend'];
     nDA = json['NDA'];
     assisted = json['assisted'];
     urgent = json['urgent'];
@@ -57,8 +45,6 @@ class FLUpgrades {
     sealed = json['sealed'];
     pfOnly = json['pf_only'];
     ipContract = json['ip_contract'];
-    recruiter = json['recruiter'];
-    listed = json['listed'];
   }
 
   Map<String, dynamic> toJson() {

--- a/test/fl_project_test.dart
+++ b/test/fl_project_test.dart
@@ -47,6 +47,7 @@ void main() async {
       expect(project.upgrades.sealed, false);
       expect(project.upgrades.pfOnly, false);
       expect(project.upgrades.ipContract, false);
+      expect(project.upgrades.assisted, false);
     });
 
     test('evaluate project budget data', () async {

--- a/test_resources/fl_project_data.json
+++ b/test_resources/fl_project_data.json
@@ -24,7 +24,7 @@
         "project_management": false,
         "extend": null,
         "NDA": false,
-        "assisted": null,
+        "assisted": false,
         "urgent": false,
         "featured": true,
         "nonpublic": false,


### PR DESCRIPTION
Check on the API response of projects API. Found out that `assisted` is actually a boolean. I removed the other properties and will confirm with the API team about their data types.